### PR TITLE
Socket Room functionality added

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -74,7 +74,7 @@ io.sockets.on('connection', function (socket) {
 	});
   socket.on('disconnect', function(){
     connectedClients--;
-    `Disconnection: now ${connectedClients} are Connected on socket server`
+    console.log(`Disconnection: now ${connectedClients} are Connected on socket server`);
   })
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,8 @@ const PORT = process.env.PORT || 3000;
 const server = app.listen(PORT);
 const io = require('socket.io').listen(server);
 
+
+// for debugging, REMOVE FOR PRODUCTION including postman endpoints
 var data = JSON.stringify([{name: 'steve', message: 'commit message by steve'}, {name: 'sarah', message: 'commit message'}]);
 var data2 = JSON.stringify([{name: 'colin', message: 'colin commit message'}, {name: 'binh', message: 'binh commit message'}]);
 

--- a/server/server.js
+++ b/server/server.js
@@ -49,9 +49,10 @@ app.get('/', function(req, res) {
 /*************
 *** Socket Handling ***
 **************/
-
+var connectedClients = 0;
 io.sockets.on('connection', function (socket) {
-  console.log("Connected on socket server");
+  connectedClients++;
+  console.log(`${connectedClients} are Connected on socket server`);
   // room handling
   socket.on('subscribe', function(data) { socket.join(data.room); console.log(`joined room:${data.room}`)})
   socket.on('unsubscribe', function(data) { socket.leave(data.room); })
@@ -69,6 +70,10 @@ io.sockets.on('connection', function (socket) {
 		console.log('Branch server event: ' + arg);
 		io.emit('incomingCommit', arg)
 	});
+  socket.on('disconnect', function(){
+    connectedClients--;
+    `Disconnection: now ${connectedClients} are Connected on socket server`
+  })
 });
 
 

--- a/server/server.js
+++ b/server/server.js
@@ -55,7 +55,7 @@ io.sockets.on('connection', function (socket) {
   console.log(`${connectedClients} are Connected on socket server`);
   // room handling
   socket.on('subscribe', function(data) { socket.join(data.room); console.log(`joined room:${data.room}`)})
-  socket.on('unsubscribe', function(data) { socket.leave(data.room); })
+  socket.on('unsubscribe', function(data) { socket.leave(data.room); console.log(`left room:${data.room}`) })
   // Socket test
   socket.once("echo", function (msg, callback) {
     socket.emit("echo", msg);

--- a/server/server.js
+++ b/server/server.js
@@ -46,20 +46,24 @@ app.get('/', function(req, res) {
   res.send('hello');
 });
 
+/*************
+*** Socket Handling ***
+**************/
+
 io.sockets.on('connection', function (socket) {
   console.log("Connected on socket server");
-
+  // room handling
+  socket.on('subscribe', function(data) { socket.join(data.room); console.log(`joined room:${data.room}`)})
+  socket.on('unsubscribe', function(data) { socket.leave(data.room); })
   // Socket test
   socket.once("echo", function (msg, callback) {
     socket.emit("echo", msg);
   });
-
   //listening for commit from local client, then broadcasts to all connected clients
 	socket.on('broadcastCommit', function(arg){
 		console.log('broadcastCommit: ' + arg);
 		io.emit('incomingCommit', arg)
 	});
-
   // listening for branch change from local client, then broadcasts to all connected clients
 	socket.on('broadcastBranch', function(arg){
 		console.log('Branch server event: ' + arg);

--- a/src/app.js
+++ b/src/app.js
@@ -11,8 +11,10 @@ import Term from './terminal/terminal.js'
 import GitTree from './gitTree';
 import { ipcRenderer } from 'electron';
 
+// Socket handling for app. Must be global to current page for ipcRenderer + React
 let socket = io('http://localhost:3000');
 let socketRoom = null;
+
 /* listens for an git commit event from main.js webContent.send
  then sends commit string to the server via socket */
 ipcRenderer.on('commitMade', function(event, arg){

--- a/src/app.js
+++ b/src/app.js
@@ -11,17 +11,18 @@ import Term from './terminal/terminal.js'
 import GitTree from './gitTree';
 import { ipcRenderer } from 'electron';
 
+let socket = io('http://localhost:3000');
 /* listens for an git commit event from main.js webContent.send
  then sends commit string to the server via socket */
 ipcRenderer.on('commitMade', function(event, arg){
-	let socket = io('http://localhost:3000');
+	//let socket = io('http://localhost:3000');
 	socket.emit('broadcastCommit', JSON.stringify(arg, null, 4))
 });
 
 /* listens for an git branch checkout event from main.js webContent.send
  then sends commit string to the server via socket */
 ipcRenderer.on('changedBranches', function(event, arg){
-	let socket = io('http://localhost:3000');
+	//let socket = io('http://localhost:3000');
 	socket.emit('broadcastBranch', JSON.stringify(arg, null, 4))
 });
 
@@ -40,8 +41,8 @@ class App extends Component {
 	}
 
 	componentDidMount() {
-		this.socket.on('test', this._handleData);
-		this.socket.on('incomingCommit', this._handleData);
+		socket.on('test', this._handleData);
+		socket.on('incomingCommit', this._handleData);
   }
 
 	_handleData(dataObj) {
@@ -71,6 +72,7 @@ class App extends Component {
 				} else {
 					console.log('error fetching Github data', error);
 				}
+				socket.emit("subscribe", { room: `${orgName}/${repoName}live` });
 			}
 		);
 

--- a/src/app.js
+++ b/src/app.js
@@ -12,18 +12,17 @@ import GitTree from './gitTree';
 import { ipcRenderer } from 'electron';
 
 let socket = io('http://localhost:3000');
+let socketRoom = null;
 /* listens for an git commit event from main.js webContent.send
  then sends commit string to the server via socket */
 ipcRenderer.on('commitMade', function(event, arg){
-	//let socket = io('http://localhost:3000');
-	socket.emit('broadcastCommit', JSON.stringify(arg, null, 4))
+	if(socketRoom) socket.emit('broadcastCommit', JSON.stringify(arg, null, 4));
 });
 
 /* listens for an git branch checkout event from main.js webContent.send
  then sends commit string to the server via socket */
 ipcRenderer.on('changedBranches', function(event, arg){
-	//let socket = io('http://localhost:3000');
-	socket.emit('broadcastBranch', JSON.stringify(arg, null, 4))
+	if(socketRoom) socket.emit('broadcastBranch', JSON.stringify(arg, null, 4));
 });
 
 
@@ -36,9 +35,9 @@ class App extends Component {
 		this._handleData = this._handleData.bind(this);
 	}
 
-	componentWillMount() {
-    this.socket = io('http://localhost:3000');
-	}
+	// componentWillMount() {
+  //   this.socket = io('http://localhost:3000');
+	// }
 
 	componentDidMount() {
 		socket.on('test', this._handleData);
@@ -73,6 +72,7 @@ class App extends Component {
 					console.log('error fetching Github data', error);
 				}
 				socket.emit("subscribe", { room: `${orgName}/${repoName}live` });
+				socketRoom = `${orgName}/${repoName}live`;
 			}
 		);
 

--- a/src/app.js
+++ b/src/app.js
@@ -71,6 +71,7 @@ class App extends Component {
 				} else {
 					console.log('error fetching Github data', error);
 				}
+				if(socketRoom) socket.emit("unsubscribe", { room: socketRoom });
 				socket.emit("subscribe", { room: `${orgName}/${repoName}live` });
 				socketRoom = `${orgName}/${repoName}live`;
 			}


### PR DESCRIPTION
Now git event updates are only shared to a specific socket channel, only after user inputs the team/repo details and clicks submit. If user reselects another team/repo, channel is disconnected and reassigned to updated team/repo. Need UI to update when new team/repo is changed (i.e. clear rendered data)
